### PR TITLE
Split packages, update entry_points, add more tests, maintainer

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @proinsias
+* @bollwyvl @proinsias

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-About python-dotenv
-===================
-
-Home: https://github.com/theskumar/python-dotenv/
-
-Package license: BSD-3-Clause
+About python-dotenv-feedstock
+=============================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/python-dotenv-feedstock/blob/main/LICENSE.txt)
 
-Summary: Get and set values in your .env file in local and production servers like Heroku does.
+Home: https://saurabh-kumar.com/python-dotenv
 
-Development: https://github.com/theskumar/python-dotenv/
+Package license: BSD-3-Clause
+
+Summary: Read key-value pairs from a .env file and set them as environment variables
+
+Development: https://github.com/theskumar/python-dotenv
 
 Current build status
 ====================
@@ -30,6 +30,8 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-python--dotenv-green.svg)](https://anaconda.org/conda-forge/python-dotenv) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-dotenv.svg)](https://anaconda.org/conda-forge/python-dotenv) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-dotenv.svg)](https://anaconda.org/conda-forge/python-dotenv) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-dotenv.svg)](https://anaconda.org/conda-forge/python-dotenv) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-python--dotenv--base-green.svg)](https://anaconda.org/conda-forge/python-dotenv-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-dotenv-base.svg)](https://anaconda.org/conda-forge/python-dotenv-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-dotenv-base.svg)](https://anaconda.org/conda-forge/python-dotenv-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-dotenv-base.svg)](https://anaconda.org/conda-forge/python-dotenv-base) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-python--dotenv--with--cli-green.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-dotenv-with-cli.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-dotenv-with-cli.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-dotenv-with-cli.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) |
 
 Installing python-dotenv
 ========================
@@ -41,16 +43,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `python-dotenv` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `python-dotenv, python-dotenv-base, python-dotenv-with-cli` can be installed with `conda`:
 
 ```
-conda install python-dotenv
+conda install python-dotenv python-dotenv-base python-dotenv-with-cli
 ```
 
 or with `mamba`:
 
 ```
-mamba install python-dotenv
+mamba install python-dotenv python-dotenv-base python-dotenv-with-cli
 ```
 
 It is possible to list all of the versions of `python-dotenv` available on your platform with `conda`:
@@ -145,5 +147,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@proinsias](https://github.com/proinsias/)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-python--dotenv-green.svg)](https://anaconda.org/conda-forge/python-dotenv) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-dotenv.svg)](https://anaconda.org/conda-forge/python-dotenv) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-dotenv.svg)](https://anaconda.org/conda-forge/python-dotenv) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-dotenv.svg)](https://anaconda.org/conda-forge/python-dotenv) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-python--dotenv--base-green.svg)](https://anaconda.org/conda-forge/python-dotenv-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-dotenv-base.svg)](https://anaconda.org/conda-forge/python-dotenv-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-dotenv-base.svg)](https://anaconda.org/conda-forge/python-dotenv-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-dotenv-base.svg)](https://anaconda.org/conda-forge/python-dotenv-base) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-python--dotenv--with--cli-green.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-dotenv-with-cli.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-dotenv-with-cli.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-dotenv-with-cli.svg)](https://anaconda.org/conda-forge/python-dotenv-with-cli) |
 
 Installing python-dotenv
@@ -43,16 +42,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `python-dotenv, python-dotenv-base, python-dotenv-with-cli` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `python-dotenv, python-dotenv-with-cli` can be installed with `conda`:
 
 ```
-conda install python-dotenv python-dotenv-base python-dotenv-with-cli
+conda install python-dotenv python-dotenv-with-cli
 ```
 
 or with `mamba`:
 
 ```
-mamba install python-dotenv python-dotenv-base python-dotenv-with-cli
+mamba install python-dotenv python-dotenv-with-cli
 ```
 
 It is possible to list all of the versions of `python-dotenv` available on your platform with `conda`:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,5 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+bot:
+  inspection: hint-all

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,84 @@
-{% set name = "python-dotenv" %}
 {% set version = "1.0.0" %}
-{% set sha256 = "a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba" %}
 
 package:
-  name: {{ name|lower }}
+  name: python-dotenv-split
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/p/python-dotenv/python-dotenv-{{ version }}.tar.gz
+  sha256: a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba
 
 build:
+  number: 1
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  entry_points:
-    - dotenv = dotenv:cli.cli
 
 requirements:
   host:
     - pip
-    - python >=2.7
-    - setuptools
+    - python >=3.8
   run:
-    - python >=2.7
-    - click >=5.0
+    - python >=3.8
 
-test:
-  imports:
-    - dotenv
+outputs:
+  - name: python-dotenv-base
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+      entry_points:
+        - dotenv=dotenv.__main__:cli
+    requirements:
+      host:
+        - pip
+        - python >=3.8
+      run:
+        - python >=3.8
+    test:
+      imports:
+        - dotenv
+
+  - name: python-dotenv-with-cli
+    build:
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.8
+      run:
+        - {{ pin_subpackage("python-dotenv-base", exact=True) }}
+        - click >=5.0
+        - python >=3.8
+    test:
+      imports:
+        - dotenv
+      commands:
+        - dotenv --help
+
+  - name: python-dotenv
+    build:
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python >=3.8
+      run:
+        - {{ pin_subpackage("python-dotenv-base", exact=True) }}
+        - {{ pin_subpackage("python-dotenv-with-cli", exact=True) }}
+        - python >=3.8
+    test:
+      imports:
+        - dotenv
+      commands:
+        - dotenv --help
 
 about:
-  home: https://github.com/theskumar/python-dotenv/
+  home: https://github.com/theskumar/python-dotenv
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Get and set values in your .env file in local and production servers like Heroku does.
-  dev_url: https://github.com/theskumar/python-dotenv/
+  summary: Read key-value pairs from a .env file and set them as environment variables
 
 extra:
+  feedstock-name: python-dotenv
   recipe-maintainers:
     - proinsias
+    - bollwyvl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,11 +81,12 @@ outputs:
         - dotenv --help
 
 about:
-  home: https://github.com/theskumar/python-dotenv
+  home: https://saurabh-kumar.com/python-dotenv
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Read key-value pairs from a .env file and set them as environment variables
+  dev_url: https://github.com/theskumar/python-dotenv
 
 extra:
   feedstock-name: python-dotenv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,10 @@ outputs:
     test:
       imports:
         - dotenv
+      requires:
+        - pip
+      commands:
+        - pip check
 
   - name: python-dotenv-with-cli
     build:
@@ -50,7 +54,10 @@ outputs:
     test:
       imports:
         - dotenv
+      requires:
+        - pip
       commands:
+        - pip check
         - dotenv --help
 
   - name: python-dotenv
@@ -67,7 +74,10 @@ outputs:
     test:
       imports:
         - dotenv
+      requires:
+        - pip
       commands:
+        - pip check
         - dotenv --help
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.8
 
 outputs:
-  - name: python-dotenv-base
+  - name: python-dotenv
     build:
       noarch: python
       script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
@@ -48,7 +48,7 @@ outputs:
         - pip
         - python >=3.8
       run:
-        - {{ pin_subpackage("python-dotenv-base", exact=True) }}
+        - {{ pin_subpackage("python-dotenv", exact=True) }}
         - click >=5.0
         - python >=3.8
     test:
@@ -60,25 +60,6 @@ outputs:
         - pip check
         - dotenv --help
 
-  - name: python-dotenv
-    build:
-      noarch: python
-    requirements:
-      host:
-        - pip
-        - python >=3.8
-      run:
-        - {{ pin_subpackage("python-dotenv-base", exact=True) }}
-        - {{ pin_subpackage("python-dotenv-with-cli", exact=True) }}
-        - python >=3.8
-    test:
-      imports:
-        - dotenv
-      requires:
-        - pip
-      commands:
-        - pip check
-        - dotenv --help
 
 about:
   home: https://saurabh-kumar.com/python-dotenv


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Changes:
- [x] update minimum python to `>=3.8`
- [x] fixes `entry_points`
  - > the existing `setuptools` derived ones are probably broken on e.g. windows
- [x] remove `click` from `python-dotenv` 
  - > my initial motivation to tidy this up for packages that use `dotenv` as a library
  - > this _has_ to carry the `entry_point`, as otherwise `setuptools` would re-make a broken one, but it won't work because of `click`
- [x] move `click` dependency to `python-dotenv-with-cli` subpackage
- [x] add `pip check`
- [x] clean up some single use/verbose jinja vars, URLs and fields
- [x] add all bot inspection hints for PRs (e.g. `grayskull`) 
- [x] add self as maintainer